### PR TITLE
Minor tweaks and renames across multiple pages

### DIFF
--- a/specifications/life_of_a_transition_controller.md
+++ b/specifications/life_of_a_transition_controller.md
@@ -32,15 +32,15 @@ Most platforms have a standard mechanism for initiating a transition. At this po
 
 To coordinate a transition, a transition controller must create a scheduler and a director.
 
-The transition controller may hold on to an object that stores both the scheduler and the director during the lifetime of the transition. Such an object could be called a `TransitionRuntime`.
+The transition controller may hold on to an object that stores both the scheduler and the director during the lifetime of the transition. Such an object could be called a `TransitionRunner`.
 
 For example:
 
-    transitionWillStart {
-      runtime = TransitionRuntime(new directorClass())
+    transitionWillStart(initialDirection) {
+      runner = TransitionRunner(directorClass(initialDirection))
     }
 
-    class TransitionRuntime {
+    class TransitionRunner {
       let scheduler
       initWithDirector(director) {
         scheduler = Scheduler()
@@ -62,4 +62,4 @@ Once the transition controller detects that the scheduler activity has idled, th
 
 > On iOS, for example, the transition controller must invoke a specific method to inform UIKit that the transition has either completed or canceled.
 
-At this point the transition controller might throw away its `TransitionRuntime` instance.
+At this point the transition controller might throw away its `TransitionRunner` instance.

--- a/specifications/life_of_a_transition_director.md
+++ b/specifications/life_of_a_transition_director.md
@@ -57,7 +57,7 @@ An instance of this type might be lazily available for any transition on our pla
 
 Provide the `FadeTransitionDirector` type to the transition controller.
 
-    transitionController.directorType = typeof(FadeTransitionDirector)
+    transitionController.directorClass = typeof(FadeTransitionDirector)
 
 ### Step 5: Initiate the transition
 

--- a/specifications/replicator.md
+++ b/specifications/replicator.md
@@ -2,7 +2,7 @@
 
 This is the engineering specification for the `ReplicaControllerDelegate` abstract type.
 
-A instance of a `Replicator` creates similar replicas of visual elements. Replicas do not necessarily need to be as functional as their original element.
+A instance of a `ReplicaControllerDelegate` creates similar replicas of visual elements. Replicas do not necessarily need to be as functional as their original element.
 
 Printable tech tree/checklist:
 
@@ -12,11 +12,11 @@ Printable tech tree/checklist:
 
 <p style="text-align:center"><tt>MVP</tt></p>
 
-**Abstract type**: `Replicator` is a protocol, if your language has that concept.
+**Abstract type**: `ReplicaControllerDelegate` is a protocol, if your language has that concept.
 
 Example pseudo-code:
 
-    protocol Replicator {
+    protocol ReplicaControllerDelegate {
     }
 
 **createReplica API**: Provide an API for replicating an element.
@@ -27,7 +27,7 @@ Returning the provided element indicates that the element has not been replicate
 
 Example pseudo-code:
 
-    protocol Replicator {
+    protocol ReplicaControllerDelegate {
       function createReplica(Element element) -> Element
     }
 

--- a/specifications/replicator_controller.md
+++ b/specifications/replicator_controller.md
@@ -58,7 +58,7 @@ Example pseudo-code:
         if disabledElements.contains(element) {
           return null
         }
-        return replicator.createReplica(element)
+        return delegate.createReplica(element)
       }
     }
 

--- a/specifications/runtime/performer.md
+++ b/specifications/runtime/performer.md
@@ -52,15 +52,15 @@ Example pseudo-code if your language does not support anonymous functions:
     }
     
     class DelegatedExecutionCallback {
-      function delegatedExecutionWillStart(performer, name)
-      function delegatedExecutionDidFinish(performer, name)
+      function delegatedExecutionWillStart(performer, planName)
+      function delegatedExecutionDidFinish(performer, planName)
     }
 
 Example pseudo-code if your language supports anonymous functions:
 
     protocol DelegatedExecution {
-      var delegatedExecutionWillStart(performer, name)
-      var delegatedExecutionDidFinish(performer, name)
+      var delegatedExecutionWillStart(performer, planName)
+      var delegatedExecutionDidFinish(performer, planName)
     }
 
 <a name="delegationv2"></a>

--- a/specifications/transition_controller.md
+++ b/specifications/transition_controller.md
@@ -5,7 +5,7 @@ Status of this document:
 
 This is the engineering specification for the `TransitionController` object.
 
-`TransitionController` is the bridge between the platform's transitioning architecture and the `TransitionDirector` type.
+The `TransitionController` is the bridge between the platform's transitioning architecture and the `TransitionDirector` type. Note that a `TransitionController` can make use of a `TransitionRunner`, an object that handles the director and the scheduler, to just focus on the the platform's transitioning API. This document assumes no such object is being used.
 
 ---
 
@@ -29,7 +29,7 @@ The type must be a subclass of `TransitionDirector`.
 Example pseudo-code:
 
     TransitionController {
-      public var directorType: type(TransitionDirector)
+      public var directorClass: typeof(TransitionDirector)
     }
 
 **Scheduler**: Store a single `Scheduler` instance while the transition is active.
@@ -69,14 +69,13 @@ Example pseudo-code:
         # Initialize the Director
         replicationController = ReplicationController()
         replicationController.duplicator = SystemDuplicator()
-        
-        director = self.directorType(initialDirection, replicationController)
+        director = self.directorClass(initialDirection, replicationController)
         
         # Phase: set up
         transaction = Transaction()
         director.setUp(transaction)
         
-        # Initialize the ruschedulerntime
+        # Initialize the scheduler
         scheduler = Scheduler()
         scheduler.addNewTargetObserver(replicationController)
         scheduler.addActivityStateObserver(self)


### PR DESCRIPTION
- Rename TransitionRuntime into TransitionRunner (less confusing imo).
- Rename Replicator references into ReplicaControllerDelegate for consistency.
- Rename Delegated execution API v1 'name' argument into 'planName' for clarity.
- Add a note to TransitionController Specs about TransitionRunners.
- Use directorClass instead of directorType for consistency.
- Fix a couple of typos.
